### PR TITLE
Add global font-scaling functionality

### DIFF
--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -7,6 +7,8 @@ pub enum AppAction {
     // HideApp,
     // ShowApp,
     OpenLink(String),
+    IncreaseFontSize,
+    DecreaseFontSize,
 }
 
 pub fn proccess_app_action(
@@ -45,5 +47,11 @@ pub fn proccess_app_action(
             }
         }
         AppAction::OpenLink(url) => ctx.open_url(OpenUrl::new_tab(url)),
+        AppAction::IncreaseFontSize => {
+            state.font_scale += 1;
+        },
+        AppAction::DecreaseFontSize => {
+            state.font_scale -= 1;
+        },
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -65,6 +65,14 @@ impl AppTheme {
             sizes: Sizes::new(),
         }
     }
+
+    pub fn scaled(&self, scaling: f32) -> Self {
+        Self {
+            fonts: self.fonts.scaled(scaling),
+            colors: self.colors.clone(),
+            sizes: self.sizes.scaled(scaling),
+        }
+    }
 }
 
 impl Default for AppTheme {
@@ -93,6 +101,17 @@ impl FontSizes {
             small: 8.,
         }
     }
+
+    pub fn scaled(&self, scaled: f32) -> Self {
+        Self {
+            h1: self.h1 * scaled,
+            h2: self.h2 * scaled,
+            h3: self.h3 * scaled,
+            h4: self.h4 * scaled,
+            normal: self.normal * scaled,
+            small: self.small * scaled,
+        }
+    }
 }
 
 impl Sizes {
@@ -113,7 +132,21 @@ impl Sizes {
             toolbar_icon: l + xs / 2.,
         }
     }
+
+    pub fn scaled(&self, scaling: f32) -> Self {
+        Self {
+            xs: self.xs * scaling,
+            s: self.s * scaling,
+            m: self.m * scaling,
+            l: self.l * scaling,
+            xl: self.xl * scaling,
+            header_footer: self.header_footer * scaling,
+            toolbar_icon: self.toolbar_icon * scaling,
+        }
+    }
 }
+
+#[derive(Debug, Clone)]
 pub struct FontFamilies {
     pub normal: FontFamily,
     pub italic: FontFamily,
@@ -139,6 +172,15 @@ pub struct FontTheme {
 
     // families
     pub family: FontFamilies,
+}
+
+impl FontTheme {
+    pub fn scaled(&self, scaling: f32) -> Self {
+        Self {
+            size: self.size.scaled(scaling),
+            family: self.family.clone(),
+        }
+    }
 }
 
 impl Default for FontTheme {


### PR DESCRIPTION
Initial prototype of font-scaling functionality using the usual shortcuts

Future improvements:
- limits to the scaling
- persistance? 
- should this be tied to the particular note?
- more support for general theme customization in the architecture