### PR TITLE
Remove max size restriction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,7 @@ fn main() {
         default_theme: eframe::Theme::Dark,
         initial_window_size: Some(vec2(350.0, 450.0)),
         min_window_size: Some(vec2(350.0, 450.0)),
-        max_window_size: Some(vec2(650.0, 750.0)),
+        // max_window_size: Some(vec2(650.0, 750.0)),
         // fullsize_content: true,
         // decorated: false,
         resizable: true,


### PR DESCRIPTION
Not sure why it was ever restricted. Let me know. I've found it hard to use some of my bigger JS notes. 