### PR TITLE
[DRAFT] Added new "settings" note + animations for picker

### DIFF
--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -3,7 +3,7 @@ use eframe::egui::{Context, Id, KeyboardShortcut, Modifiers, OpenUrl};
 use smallvec::SmallVec;
 
 use crate::{
-    app_state::AppState,
+    app_state::{AppState, NoteSelection},
     byte_span::{ByteSpan, RangeRelation, UnOrderedByteSpan},
     commands::EditorCommand,
     text_structure::{ListDesc, SpanKind, SpanMeta, TextStructure},
@@ -63,6 +63,8 @@ pub enum AppAction {
     OpenLink(String),
     IncreaseFontSize,
     DecreaseFontSize,
+    OpenSettings,
+    CloseSettings,
 }
 
 pub fn process_app_action(
@@ -76,7 +78,7 @@ pub fn process_app_action(
             index,
             via_shortcut,
         } => {
-            if index != state.selected_note {
+            if NoteSelection::Note(index) != state.selected_note {
                 state.save_to_storage = true;
 
                 if via_shortcut {
@@ -96,12 +98,12 @@ pub fn process_app_action(
                     // means that we reselected via UI
 
                     // if that is the case then reset cursors from both of the notes
-                    state.notes[state.selected_note as usize].cursor = None;
+                    //TODO state.notes[state.selected_note as usize].cursor = None;
                     state.notes[index as usize].cursor = None;
                 }
 
                 let text = &state.notes[index as usize].text;
-                state.selected_note = index;
+                state.selected_note = NoteSelection::Note(index);
                 state.text_structure = state.text_structure.take().map(|s| s.recycle(text));
             }
         }
@@ -112,6 +114,21 @@ pub fn process_app_action(
         AppAction::DecreaseFontSize => {
             state.font_scale -= 1;
         }
+        AppAction::OpenSettings => {
+            match state.selected_note {
+                NoteSelection::Note(index) => state.selected_note = NoteSelection::Settings { prev_note: index },
+                _ => {},
+            }
+        } 
+        AppAction::CloseSettings => {
+             match state.selected_note {
+                NoteSelection::Settings { prev_note } => state.selected_note = NoteSelection::Note(prev_note ),
+                _ => {},
+            }
+        }
+        // AppAction::CloseSettings => {
+          //     state.is_settings_opened = false;
+          // }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,8 +116,11 @@ impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
         let text_edit_id = Id::new("text_edit");
 
-        let app_state = &mut self.state;
-        let note = &mut app_state.notes[app_state.selected_note as usize];
+        let app_state: &mut AppState = &mut self.state;
+        let note = match app_state.selected_note {
+            app_state::NoteSelection::Note(index) => &mut app_state.notes[index as usize],
+            app_state::NoteSelection::Settings { .. } => &mut app_state.settings_note,
+        };
         let mut cursor: Option<UnOrderedByteSpan> = note.cursor;
 
         let editor_text = &mut note.text;
@@ -216,7 +219,7 @@ impl eframe::App for MyApp {
         }
 
         let vis_state = AppRenderData {
-            selected_note: app_state.selected_note,
+            selected_note: &app_state.selected_note,
             text_edit_id,
             font_scale: app_state.font_scale,
             byte_cursor: cursor,
@@ -237,7 +240,7 @@ impl eframe::App for MyApp {
 
         app_state.text_structure = Some(updated_structure);
         app_state.computed_layout = updated_layout;
-        app_state.notes[app_state.selected_note as usize].cursor = byte_cursor;
+        note.cursor = byte_cursor;
 
         for action in actions {
             process_app_action(action, ctx, app_state, text_edit_id);

--- a/src/persistent_state.rs
+++ b/src/persistent_state.rs
@@ -3,5 +3,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PersistentState {
     pub notes: Vec<String>,
+    pub settings_note: String,
     pub selected_note: u32,
 }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -13,8 +13,16 @@ pub struct PickerItem {
     pub tooltip: String,
 }
 
+// TODO This is a pretty shitty enum. The reason is that the animation code is built around the currently selected note.
+// When settings is selected, there is no current note. Either A) we move settings in here B) we make the animation logic
+// central, instead of per note.
+pub enum PickerSelection {
+    Selected(u32),
+    Deselected(u32),
+}
+
 pub struct Picker<'a> {
-    pub current: &'a mut u32,
+    pub current: &'a mut PickerSelection,
     pub items: &'a [PickerItem],
     pub gap: f32,
     pub radius: f32,
@@ -98,12 +106,20 @@ impl<'a> Widget for Picker<'a> {
                         let mut point_response = ui.interact(rect, point_id, Sense::click());
 
                         if point_response.clicked() {
-                            *current = i;
+                            *current = PickerSelection::Selected(i);
                         }
 
-                        let is_selected = i == *current;
+                        let is_current_index = match current {
+                            PickerSelection::Selected(selected_index)
+                            | PickerSelection::Deselected(selected_index) => *selected_index == i,
+                        };
 
-                        if !is_selected {
+                        let is_selected = match current {
+                            PickerSelection::Selected(selected_index) => *selected_index == i,
+                            PickerSelection::Deselected(_) => false,
+                        };
+
+                        if !is_current_index {
                             let tooltip_ui = |ui: &mut egui::Ui| {
                                 ui.label(
                                     RichText::new(&items[i as usize].tooltip).color(tooltip_text),
@@ -134,6 +150,11 @@ impl<'a> Widget for Picker<'a> {
                             _ => Stroke::new(1.0, inactive),
                         };
 
+                        let center_y_target = if is_selected {
+                            center.y - 1. * radius / 2.0
+                        } else {
+                            center.y
+                        };
                         let center = pos2(center.x, center.y - selection_progress * radius / 2.0);
 
                         painter.add(epaint::CircleShape {
@@ -143,28 +164,136 @@ impl<'a> Widget for Picker<'a> {
                             stroke,
                         });
 
-                        if is_selected {
+                        // Important Note: All of the animation code below needs a complete re-write.
+                        // I was hacking to just see if I could make it work, but ran into a lot of trouble.
+                        // TODO Fix it.
+                        //  - Realized that we don't actually need to have each interpolation be its own animation.
+                        //  - There's some complexity where certain values depend on other (now animated) values.
+                        //  - There's also multiple different animations going on: Translation (selecting different note), Selection (settings <-> note).
+                        if is_current_index {
                             let top_rounding = gap;
 
                             // the outline will be right in between dots
                             let drop_radius = radius + gap / 2.;
 
-                            let drop_x = ctx.animate_value_with_time(
+                            let drop_x_target = center.x;
+
+                            let drop_x_animated = ctx.animate_value_with_time(
                                 response.id.with("drop"),
-                                center.x,
+                                drop_x_target,
                                 0.2,
                             );
 
-                            let drop_pos = pos2(drop_x, center.y);
+                            let drop_y_target = if is_selected {
+                                center_y_target
+                            } else {
+                                available_rect.top()
+                            };
 
-                            let space_above = drop_pos.y - available_rect.top();
+                            let drop_y_animated = ctx.animate_value_with_time(
+                                response.id.with("drop-y"),
+                                drop_y_target,
+                                0.2,
+                            );
+
+                            let drop_radius_target = if is_selected { drop_radius } else { 0.0 };
+                            let drop_radius_animated = ctx.animate_value_with_time(
+                                response.id.with("drop-radius"),
+                                drop_radius_target,
+                                0.2,
+                            );
+
+                            let top_rounding_target = if is_selected { top_rounding } else { 0.0 };
+                            let top_rounding_animated = ctx.animate_value_with_time(
+                                response.id.with("drop-top-rounding"),
+                                top_rounding_target,
+                                0.2,
+                            );
+
+                            let drop_pos_animated = pos2(drop_x_animated, drop_y_animated);
+
+                            let half_drop_x_target = if is_selected {
+                                available_rect.right()
+                            } else {
+                                available_rect.right() - radius - gap / 2.0
+                            };
+
+                            let half_drop_x_animated = ctx.animate_value_with_time(
+                                response.id.with("half-drop-x"),
+                                half_drop_x_target,
+                                0.2,
+                            );
+
+                            let half_drop_y_target = if is_selected {
+                                available_rect.top()
+                            } else {
+                                center_y_target
+                            };
+
+                            let half_drop_y_animated = ctx.animate_value_with_time(
+                                response.id.with("half-drop-y"),
+                                half_drop_y_target,
+                                0.2,
+                            );
+
+                            let half_drop_radius_target =
+                                if is_selected { 0.0 } else { radius + gap / 2. };
+                            let half_drop_radius_animated = ctx.animate_value_with_time(
+                                response.id.with("half-drop-radius"),
+                                half_drop_radius_target,
+                                0.2,
+                            );
+
+                            let half_top_rounding_target = if is_selected { 0.0 } else { gap };
+                            let half_top_rounding_animated = ctx.animate_value_with_time(
+                                response.id.with("half-drop-top_rounding"),
+                                half_top_rounding_target,
+                                0.2,
+                            );
+
+                            let half_drop_pos_animated =
+                                pos2(half_drop_x_animated, half_drop_y_animated);
+
+                            // let space_above = drop_pos.y - available_rect.top();
+                            let space_above_target = if is_selected {
+                                drop_y_target - available_rect.top()
+                            } else {
+                                0.0
+                            };
+                            let space_above_animated = ctx.animate_value_with_time(
+                                response.id.with("drop-space-above"),
+                                space_above_target,
+                                0.2,
+                            );
+
+                            let half_drop_space_above_target = if is_selected {
+                                0.0
+                            } else {
+                                half_drop_y_target - available_rect.top()
+                            };
+                            let half_drop_space_above_animated = ctx.animate_value_with_time(
+                                response.id.with("half-drop-space-above"),
+                                half_drop_space_above_target,
+                                0.2,
+                            );
 
                             // TODO, cache producing path in the widget state
                             let mut drop_shape = Shape::Path(PathShape {
                                 points: drop_path(DropPathDesc {
-                                    radius: drop_radius,
-                                    total_space_above: space_above,
-                                    top_rounding,
+                                    radius: drop_radius_animated,
+                                    total_space_above: space_above_animated,
+                                    top_rounding: top_rounding_animated,
+                                }),
+                                closed: false,
+                                fill: Color32::TRANSPARENT,
+                                stroke: outline,
+                            });
+
+                            let mut half_drop_shape = Shape::Path(PathShape {
+                                points: half_drop_path(DropPathDesc {
+                                    radius: half_drop_radius_animated,
+                                    total_space_above: half_drop_space_above_animated,
+                                    top_rounding: half_top_rounding_animated,
                                 }),
                                 closed: false,
                                 fill: Color32::TRANSPARENT,
@@ -175,7 +304,9 @@ impl<'a> Widget for Picker<'a> {
                                 [
                                     available_rect.left_top(),
                                     pos2(
-                                        (drop_pos.x - top_rounding - drop_radius)
+                                        (drop_pos_animated.x
+                                            - top_rounding_animated
+                                            - drop_radius_animated)
                                             .max(available_rect.left()),
                                         available_rect.top(),
                                     ),
@@ -186,17 +317,28 @@ impl<'a> Widget for Picker<'a> {
                             painter.line_segment(
                                 [
                                     pos2(
-                                        (drop_pos.x + top_rounding + drop_radius)
+                                        (drop_pos_animated.x
+                                            + top_rounding_animated
+                                            + drop_radius_animated)
                                             .min(available_rect.right()),
                                         available_rect.top(),
                                     ),
-                                    available_rect.right_top(),
+                                    pos2(
+                                        (half_drop_pos_animated.x
+                                            - half_top_rounding_animated
+                                            - half_drop_radius_animated)
+                                            .min(available_rect.right()),
+                                        available_rect.top(),
+                                    ),
                                 ],
                                 outline,
                             );
 
-                            drop_shape.translate(drop_pos.to_vec2());
+                            drop_shape.translate(drop_pos_animated.to_vec2());
                             painter.add(drop_shape);
+
+                            half_drop_shape.translate(half_drop_pos_animated.to_vec2());
+                            painter.add(half_drop_shape);
                         }
 
                         offset += box_size
@@ -229,6 +371,38 @@ struct DropPathDesc {
     radius: f32,
     total_space_above: f32,
     top_rounding: f32,
+}
+
+// TODO need better name.
+fn half_drop_path(
+    DropPathDesc {
+        radius,
+        total_space_above,
+        top_rounding,
+    }: DropPathDesc,
+) -> Vec<Pos2> {
+    let mut path: Vec<Pos2> = vec![];
+
+    // top left rounding
+    add_circle_quadrant(
+        &mut path,
+        pos2(-radius - top_rounding, -total_space_above + top_rounding),
+        top_rounding,
+        3.0,
+    );
+
+    // line down to baseline (center of the bigger radius)
+    // will be done automatically
+
+    // big smile consisting of two quadrants
+    let mut smile: Vec<Pos2> = vec![];
+    add_circle_quadrant(&mut smile, pos2(0., 0.), radius, 1.0);
+    // it has to be in reverse order, because it goes counterclockwise
+    smile.reverse();
+
+    path.extend(smile.iter());
+
+    path
 }
 
 fn drop_path(


### PR DESCRIPTION
- Changed selected_note to be an enum variant (note vs settings)
- When opening settings, the prev note is persisted since you can close settings
- Added some picker animations to support the usecases:
  - The note selection hides away (collapses into a line)
  - The settings button is highlighted
  - The right side of the footer separator drops down 

Note: Animation code needs a re-write. Spent too much time trying to figure out why it wasn't working, so didn't have time to clean it up. But honestly, think I need some pairing to figure out the best way to do it. (original issue: At some point, it became obvious that because animated values were depending on other animated values, it would mess up the timing)

https://github.com/twop/shelv/assets/848095/623a03a9-ba9a-4162-91c4-089f8150c6f3

