### PR TITLE
Use unique IDs for the egui text editors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -193,9 +193,12 @@ impl MyApp {
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
-        let text_edit_id = Id::new("text_edit");
-
         let app_state = &mut self.state;
+        let text_edit_id = Id::new(match &app_state.selected_note {
+            NoteFile::Note(index) => format!("text_edit_id_{}", index),
+            NoteFile::Settings => "text_edit_id_settings".to_string(),
+        });
+
         // handling message queue
         let mut action_list = EditorCommandOutput::from_iter(
             app_state


### PR DESCRIPTION
It seems to be enough to fix the undo stack being wrong when you switch between notes. 