### PR TITLE
Only trigger tray icon visibility toggle on click

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use scripting::execute_live_scripts;
 use smallvec::SmallVec;
 use text_structure::TextStructure;
 use theme::{configure_styles, get_font_definitions};
-use tray_icon::{Icon, TrayIcon, TrayIconBuilder, TrayIconEvent};
+use tray_icon::{Icon, MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 // use tray_item::TrayItem;G1
 
 use std::{
@@ -115,8 +115,17 @@ impl MyApp {
         let ctx = cc.egui_ctx.clone();
         let sender = msg_queue_tx.clone();
         TrayIconEvent::set_event_handler(Some(move |ev| {
-            sender.send(MsgToApp::ToggleVisibility).unwrap();
-            ctx.request_repaint();
+            match &ev {
+                TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Down,
+                    ..
+                } => {
+                    sender.send(MsgToApp::ToggleVisibility).unwrap();
+                    ctx.request_repaint();
+                }
+                _ => {}
+            }
 
             println!("tray event: {:?}", ev);
         }));


### PR DESCRIPTION
Perhaps something changed in a refactoring, but it looks like the current implementation triggers the visibility event on any event (including mouse moves, etc.). This causes Shelv to flicker in and out as you hovered the tray icon. 

I'm going to also add the quit button since it's a launch blocker and should be easy. 