### PR TITLE
Fix github actions build to use nightly toolchain

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
@@ -26,7 +26,9 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
       - name: 🔨 Build
         uses: actions-rs/cargo@v1
         with:

--- a/_rust-toolchain.toml
+++ b/_rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "nightly-2024-05-23"
-components = ["rustfmt", "rustc-dev"]
-targets = ["nightly-aarch64-apple-darwin"]
-profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
I think the toolchain file is better now, it doesn't seem to force re-installing every time.