### PR TITLE
exposed all built ins to settings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -312,7 +312,10 @@ impl eframe::App for MyApp {
                             Some(keyboard_shortcut)
                                 if is_shortcut_match(input, &keyboard_shortcut) =>
                             {
-                                println!("---Found a match for {}", editor_command.name);
+                                println!(
+                                    "---Found a match for {:?}",
+                                    editor_command.kind.map(|k| k.human_description())
+                                );
                                 let res = (editor_command.try_handle)(CommandContext { app_state });
 
                                 if !res.is_empty() {


### PR DESCRIPTION
closes #85.

demo:

https://github.com/user-attachments/assets/6ba0d1b3-facb-40b1-8099-ee8cc536f542

https://x.com/shelvdotapp/status/1821960674144100811

```rs
pub fn default_keybinding(self) -> eframe::egui::KeyboardShortcut {
        use eframe::egui::{Key, Modifiers};
        use BuiltInCommand::*;
        let shortcut = KeyboardShortcut::new;
        match self {
            ExpandTaskMarker => shortcut(Modifiers::NONE, Key::Space),
            IndentListItem => shortcut(Modifiers::NONE, Key::Tab),
            UnindentListItem => shortcut(Modifiers::SHIFT, Key::Tab),
            SplitListItem => shortcut(Modifiers::NONE, Key::Enter),
            MarkdownCodeBlock => shortcut(Modifiers::COMMAND.plus(Modifiers::ALT), Key::B),
            MarkdownBold => shortcut(Modifiers::COMMAND, Key::B),
            MarkdownItalic => shortcut(Modifiers::COMMAND, Key::I),
            MarkdownStrikethrough => shortcut(Modifiers::COMMAND.plus(Modifiers::SHIFT), Key::E),
            MarkdownH1 => shortcut(Modifiers::COMMAND.plus(Modifiers::ALT), Key::Num1),
            MarkdownH2 => shortcut(Modifiers::COMMAND.plus(Modifiers::ALT), Key::Num2),
            MarkdownH3 => shortcut(Modifiers::COMMAND.plus(Modifiers::ALT), Key::Num3),
            SwitchToNote(0) => shortcut(Modifiers::COMMAND, Key::Num1),
            SwitchToNote(1) => shortcut(Modifiers::COMMAND, Key::Num2),
            SwitchToNote(2) => shortcut(Modifiers::COMMAND, Key::Num3),
            SwitchToNote(3) => shortcut(Modifiers::COMMAND, Key::Num4),
            // TODO figure out how to make it more bulletproof, option maybe?
            SwitchToNote(_) => shortcut(Modifiers::COMMAND, Key::Num0),
            SwitchToSettings => shortcut(Modifiers::COMMAND, Key::Comma),
            PinWindow => shortcut(Modifiers::COMMAND, Key::P),
            HideApp => shortcut(Modifiers::NONE, Key::Escape),
        }
    }
```

and 
```rs
impl BuiltInCommand {
    fn name(&self) -> &'static str {
        use BuiltInCommand::*;
        match self {
            ExpandTaskMarker => "ExpandTaskMarker",
            IndentListItem => "IndentListItem",
            UnindentListItem => "UnindentListItem",
            SplitListItem => "SplitListItem",
            MarkdownBold => "MarkdownBold",
            MarkdownItalic => "MarkdownItalic",
            MarkdownStrikethrough => "MarkdownStrikethrough",
            MarkdownCodeBlock => "MarkdownCodeBlock",
            MarkdownH1 => "MarkdownH1",
            MarkdownH2 => "MarkdownH2",
            MarkdownH3 => "MarkdownH3",
            SwitchToNote(_) => "SwitchToNote",
            SwitchToSettings => "SwitchToSettings",
            PinWindow => "PinWindow",
            HideApp => "HideApp",
        }
    }
}
```