### PR TITLE
Add network (client) entitlements

### DIFF
--- a/distribution/entitlements.xml
+++ b/distribution/entitlements.xml
@@ -8,5 +8,7 @@
 	<string>X86RP53R29</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Now that we use network requests for AI, we need this entitlement.

https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_network_client