### PR TITLE
WIP: appending feedback to the note on feedback

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -314,11 +314,8 @@ impl AppState {
                 execute_code_blocks(&mut cx, &TextStructure::new(&settings.text), &settings.text)
             } {
                 Some(requested_changes) => {
-                    match apply_text_changes(
-                        &mut settings.text,
-                        settings.cursor.unwrap_or(UnOrderedByteSpan::new(0, 0)),
-                        requested_changes,
-                    ) {
+                    match apply_text_changes(&mut settings.text, settings.cursor, requested_changes)
+                    {
                         Ok(_) => println!("applied settings note successfully"),
                         Err(err) => println!("failed to write back settings results {:#?}", err),
                     }

--- a/src/commands/enter_in_list.rs
+++ b/src/commands/enter_in_list.rs
@@ -263,8 +263,8 @@ mod tests {
             ))
             .unwrap();
 
-            let cursor = apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
-            let res = TextChange::encode_cursor(&text, cursor);
+            let cursor = apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
+            let res = TextChange::encode_cursor(&text, cursor.unwrap());
 
             println!("{desc}\ninitial:\n{input}\nres:\n{res}\nexpected:\n{expected}");
             assert_eq!(res, expected, "test case: {}", desc);
@@ -283,8 +283,11 @@ mod tests {
         let changes =
             on_enter_inside_list_item(TextCommandContext::new(&structure, &text, cursor)).unwrap();
 
-        let cursor = apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
-        assert_eq!(TextChange::encode_cursor(&text, cursor), "- item\n- {||}");
+        let cursor = apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
+        assert_eq!(
+            TextChange::encode_cursor(&text, cursor.unwrap()),
+            "- item\n- {||}"
+        );
     }
 
     #[test]
@@ -300,8 +303,11 @@ mod tests {
             on_enter_inside_list_item(TextCommandContext::new(&structure, &text, cursor.clone()))
                 .unwrap();
 
-        let cursor = apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
-        assert_eq!(TextChange::encode_cursor(&text, cursor), "- *item*\n- {||}");
+        let cursor = apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
+        assert_eq!(
+            TextChange::encode_cursor(&text, cursor.unwrap()),
+            "- *item*\n- {||}"
+        );
     }
 
     #[test]

--- a/src/commands/space_after_task_markers.rs
+++ b/src/commands/space_after_task_markers.rs
@@ -121,9 +121,9 @@ mod tests {
             ))
             .unwrap();
 
-            let cursor = apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
+            let cursor = apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
             assert_eq!(
-                TextChange::encode_cursor(&text, cursor),
+                TextChange::encode_cursor(&text, cursor.unwrap()),
                 output,
                 "test case: {}",
                 desc

--- a/src/commands/tabbing_in_list.rs
+++ b/src/commands/tabbing_in_list.rs
@@ -263,9 +263,9 @@ mod tests {
                 (None, None) => (),
                 (Some(changes), Some(expected_output)) => {
                     let cursor =
-                        apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
+                        apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
                     assert_eq!(
-                        TextChange::encode_cursor(&text, cursor),
+                        TextChange::encode_cursor(&text, cursor.unwrap()),
                         expected_output,
                         "test case: {}",
                         desc
@@ -311,10 +311,10 @@ mod tests {
                 (None, None) => (),
                 (Some(changes), Some(expected_output)) => {
                     let cursor =
-                        apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
+                        apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
 
                     assert_eq!(
-                        TextChange::encode_cursor(&text, cursor),
+                        TextChange::encode_cursor(&text, cursor.unwrap()),
                         expected_output,
                         "test case: {}",
                         desc

--- a/src/commands/toggle_code_block.rs
+++ b/src/commands/toggle_code_block.rs
@@ -93,9 +93,9 @@ mod tests {
                 toggle_code_block(TextCommandContext::new(&structure, &text, cursor.clone()))
                     .unwrap();
 
-            let cursor = apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
+            let cursor = apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
             assert_eq!(
-                TextChange::encode_cursor(&text, cursor),
+                TextChange::encode_cursor(&text, cursor.unwrap()),
                 output,
                 "test case: {}",
                 desc

--- a/src/commands/toggle_md_headings.rs
+++ b/src/commands/toggle_md_headings.rs
@@ -208,10 +208,10 @@ mod tests {
                 (None, None) => (),
                 (Some(changes), Some(expected_output)) => {
                     let cursor =
-                        apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
+                        apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
 
                     assert_eq!(
-                        TextChange::encode_cursor(&text, cursor),
+                        TextChange::encode_cursor(&text, cursor.unwrap()),
                         expected_output,
                         "test case: {}",
                         desc

--- a/src/commands/toggle_simple_md_annotations.rs
+++ b/src/commands/toggle_simple_md_annotations.rs
@@ -77,9 +77,9 @@ mod tests {
             )
             .unwrap();
 
-            let cursor = apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
+            let cursor = apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
             assert_eq!(
-                TextChange::encode_cursor(&text, cursor),
+                TextChange::encode_cursor(&text, cursor.unwrap()),
                 output,
                 "test case: {}",
                 desc

--- a/src/scripting.rs
+++ b/src/scripting.rs
@@ -404,8 +404,8 @@ Error: yo!
             match (changes, expected_output) {
                 (Some(changes), Some(expected_output)) => {
                     let cursor =
-                        apply_text_changes(&mut text, cursor.unordered(), changes).unwrap();
-                    let res = TextChange::encode_cursor(&text, cursor);
+                        apply_text_changes(&mut text, Some(cursor.unordered()), changes).unwrap();
+                    let res = TextChange::encode_cursor(&text, cursor.unwrap());
                     println!("res:\n{res:#}\n\nexpected:{expected_output:#}");
                     assert_eq!(res, expected_output, "test case: \n{}\n", desc)
                 }


### PR DESCRIPTION
TODO:

- [x] make `apply_text_changes` to accept `Option<UnOrderedByteSpan>` and return the same

<img width="480" alt="image" src="https://github.com/user-attachments/assets/2e6aea46-ae91-40f7-8284-1b5b1f570c3b">

Logic:
- if we don't have cursor then we don't have to move it with changes (current complex logic of cursor replacement)
- Or if we have a chunk that explicitly sets the cursor with `{|}` or `{||}` => initialize it with it