### PR TITLE
added syntax highlighting for settings using tree-sitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,13 +585,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.104"
+version = "1.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -3771,9 +3771,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4280,8 +4280,16 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tray-icon",
+ "tree-sitter-highlight",
+ "tree-sitter-kdl",
  "winit",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4660,18 +4668,18 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4966,6 +4974,37 @@ dependencies = [
  "png",
  "thiserror",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+dependencies = [
+ "cc",
+ "regex",
+]
+
+[[package]]
+name = "tree-sitter-highlight"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
+dependencies = [
+ "regex",
+ "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-kdl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8210c4fd8ed07c38f4dafab4855c3124f087f6392085d09750f8247304c67157"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ tokio-stream = "0.1.15"
 sentry = "0.34.0"
 fxhash = "0.2.1"
 similar = "2.6.0"
+tree-sitter-highlight = "0.20.1"
+tree-sitter-kdl = "1.1.0"
 
 [patch.crates-io]
 winit = { git = 'https://github.com/mpasalic/winit-no-private-apis.git', branch = "private-apis-removed-for-0.29.15" }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -298,10 +298,10 @@ impl ColorTheme {
         // Very dark or light color (for corresponding theme).
         // Used as the background of text edits, scroll bars and others things
         // that needs to look different from other interactive stuff.
-        let extreme_bg_color = Nord::NORD0.shade(0.5);
+        let extreme_bg_color = Nord::NORD0.shade(0.45);
 
         // Background color behind code-styled monospaced labels.
-        let code_bg_color = Nord::NORD0;
+        let code_bg_color = Nord::NORD0.shade(0.6);
         // let code_bg_color = Color32::from_black_alpha(20);
 
         // A good color for warning text (e.g. orange).


### PR DESCRIPTION
current iteration:

<img width="575" alt="image" src="https://github.com/user-attachments/assets/8676eafc-465a-4f73-8d3d-ba8d034fa311">
