### PR TITLE
Update checker (backend min-version route + app checker with header UI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2081,9 +2081,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2293,7 +2293,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -2314,21 +2314,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2613,6 +2620,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2818,9 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4085,7 +4102,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4120,7 +4137,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4322,9 +4339,9 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4340,36 +4357,32 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
- "windows-registry",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
@@ -4508,15 +4521,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -4863,6 +4867,7 @@ dependencies = [
  "miette 7.5.0",
  "objc2 0.5.2",
  "pulldown-cmark",
+ "reqwest",
  "ron",
  "sentry",
  "serde",
@@ -5035,6 +5040,16 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5498,7 +5513,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -5634,12 +5649,14 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
+ "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6246,6 +6263,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6424,8 +6450,8 @@ checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
- "windows-strings",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6459,13 +6485,13 @@ checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "6c44a98275e31bfd112bb06ba96c8ab13c03383a3753fdddd715406a1824c7e0"
 dependencies = [
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-link",
+ "windows-result 0.3.1",
+ "windows-strings 0.3.1",
 ]
 
 [[package]]
@@ -6478,13 +6504,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ miette = { version = "7.2.0", features = ["fancy"] }
 strip-ansi-escapes = "0.2.0"
 chrono = "0.4.40"
 egui_taffy = "0.7.0"
+reqwest = "0.12.23"
 
 [patch.crates-io]
 winit = { git = 'https://github.com/mpasalic/winit-no-private-apis.git', branch = "private-apis-removed-for-0.30.9" }

--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -1,6 +1,10 @@
-use axum::{extract::State, http::StatusCode, response::Html};
+use axum::{
+    Json,
+    {extract::State, http::StatusCode, response::Html},
+};
 use enum_router::router;
 use hyped::*;
+use serde::{Deserialize, Serialize};
 use std::{
     net::SocketAddr,
     sync::{Arc, Mutex},
@@ -213,6 +217,8 @@ pub struct ButtonStyle {
 pub enum Route {
     #[get("/")]
     Root,
+    #[get("/min-version")]
+    MinVersion,
 
     #[get("/privacy")]
     Privacy,
@@ -234,6 +240,20 @@ fn strip_out_newlines(text: &str) -> String {
 // Route handlers
 async fn root() -> Html<String> {
     Html(render_to_string(home_page()))
+}
+
+// TODO Replace this type with the one in the shared lib once that exists
+#[derive(Serialize, Deserialize)]
+struct VersionResponse {
+    min_version: String,
+    latest_version: String,
+}
+
+async fn min_version() -> Json<VersionResponse> {
+    Json(VersionResponse {
+        min_version: "1.3.0".to_string(),
+        latest_version: "1.3.0".to_string(),
+    })
 }
 
 async fn privacy() -> &'static str {

--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -1,9 +1,6 @@
 use std::{collections::BTreeMap, io, path::PathBuf};
 
-use eframe::egui::{
-    Context, FontId, Id, KeyboardShortcut, OpenUrl, TextFormat, ViewportCommand,
-    text::{LayoutJob, LayoutSection},
-};
+use eframe::egui::{Context, Id, KeyboardShortcut, OpenUrl, ViewportCommand, text::LayoutJob};
 
 use serde_json::{Value, to_value};
 use similar::{ChangeTag, TextDiff};
@@ -13,7 +10,7 @@ use crate::{
     app_state::{
         AppState, CodeBlockAnnotation, FeedbackState, InlineLLMPromptState, InlineLLMResponseChunk,
         InlinePromptStatus, MsgToApp, ParsedPromptResponse, RenderAction, SlashPalette,
-        TextSelectionAddress, UnsavedChange, compute_editor_text_id,
+        TextSelectionAddress, UnsavedChange, VersionState, compute_editor_text_id,
     },
     byte_span::{ByteSpan, UnOrderedByteSpan},
     command::{AppFocus, AppFocusState, CommandContext, CommandList},
@@ -178,6 +175,8 @@ pub trait AppIO {
         F: FnOnce(&mut sentry::Scope);
 
     fn copy_to_clipboard(&self, text: String);
+
+    fn start_update_checker(&self);
 }
 
 pub fn process_app_action(
@@ -576,6 +575,14 @@ pub fn process_app_action(
                         SmallVec::new()
                     }
                 },
+                MsgToApp::UpdateRequired(required_version) => {
+                    state.version_state = VersionState::RequiredUpdateAvailable(required_version);
+                    SmallVec::new()
+                }
+                MsgToApp::UpdateAvailable(latest_version) => {
+                    state.version_state = VersionState::UpdateAvailable(latest_version);
+                    SmallVec::new()
+                }
             }
         }
 

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -42,6 +42,7 @@ use crate::{
     persistent_state::{DataToSave, NoteFile, RestoredData},
     scripting::settings_eval::Scripts,
     settings_parsing::LlmSettings,
+    shared::Version,
     text_structure::{
         CodeBlockMeta, SpanIndex, SpanKind, SpanMeta, TextDiffPart, TextHash, TextStructure,
     },
@@ -79,6 +80,13 @@ pub struct InlineLLMPromptState {
     pub layout_job: LayoutJob,
     pub status: InlinePromptStatus,
     pub fresh_response: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum VersionState {
+    UpToDate,
+    UpdateAvailable(Version),
+    RequiredUpdateAvailable(Version),
 }
 
 #[derive(Debug, Clone)]
@@ -205,6 +213,7 @@ pub struct AppState {
     pub deferred_actions: Vec<AppAction>,
     pub render_actions: Vec<RenderAction>,
     pub feedback: Option<FeedbackState>,
+    pub version_state: VersionState,
 }
 
 impl AppState {
@@ -350,6 +359,8 @@ pub enum MsgToApp {
         response: InlineLLMResponseChunk,
         address: TextSelectionAddress,
     },
+    UpdateRequired(Version),
+    UpdateAvailable(Version),
 }
 
 // struct MdAnnotationShortcut {
@@ -518,6 +529,7 @@ impl AppState {
             settings_scripts: None,
             render_actions: vec![],
             feedback: None,
+            version_state: VersionState::UpToDate,
         }
     }
 

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -1,0 +1,12 @@
+// TODO Move this to a shared lib once we migrate to Cargo workspaces
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Version(pub String);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VersionResponse {
+    pub min_version: Version,
+    pub latest_version: Version,
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -37,6 +37,7 @@ pub enum AppIcon {
     Send,
     Error,
     Copy,
+    Download,
 }
 
 impl AppIcon {
@@ -45,6 +46,56 @@ impl AppIcon {
             .family(eframe::epaint::FontFamily::Name("phosphor".into()))
             .color(color)
             .size(size)
+    }
+
+    pub fn render_with_text_size(
+        &self,
+        icon_size: f32,
+        text_size: f32,
+        color: Color32,
+        text: &str,
+    ) -> WidgetText {
+        use egui::{FontId, TextFormat, text::LayoutJob};
+
+        let mut job = LayoutJob::default();
+
+        // Add icon
+        job.append(
+            self.to_icon_str(),
+            0.0,
+            TextFormat {
+                font_id: FontId::new(icon_size, FontFamily::Name("phosphor".into())),
+                color,
+                valign: egui::Align::Center,
+                ..Default::default()
+            },
+        );
+
+        // Add a space between icon and text
+        job.append(
+            "  ",
+            0.0,
+            TextFormat {
+                font_id: FontId::new(text_size, FontFamily::Name("inter".into())),
+                valign: egui::Align::Center,
+                color,
+                ..Default::default()
+            },
+        );
+
+        // Add text
+        job.append(
+            text,
+            0.0,
+            TextFormat {
+                font_id: FontId::new(text_size, FontFamily::Name("inter".into())),
+                valign: egui::Align::Center,
+                color,
+                ..Default::default()
+            },
+        );
+
+        WidgetText::LayoutJob(job)
     }
 
     pub fn render_with_text(&self, size: f32, color: Color32, text: &str) -> WidgetText {
@@ -118,6 +169,7 @@ impl AppIcon {
             AppIcon::Send => P::PAPER_PLANE_TILT,
             AppIcon::Error => P::WARNING,
             AppIcon::Copy => P::COPY_SIMPLE,
+            AppIcon::Download => P::DOWNLOAD_SIMPLE,
         }
     }
 }


### PR DESCRIPTION
<img width="817" height="96" alt="Screenshot 2025-09-21 at 11 55 03 AM" src="https://github.com/user-attachments/assets/357d90d2-77fe-4f63-902d-d6a9fbe7e022" />
<img width="818" height="72" alt="Screenshot 2025-09-21 at 11 55 32 AM" src="https://github.com/user-attachments/assets/79abd27e-f706-4e1f-8a2c-ddd0da59b968" />

- backend serves "/min-version" route
- app loops forever every 10 mins to check
- ended up modifying AppIcon to support text to make the update UI look right
- TODO move shared.rs to its own lib workspace