### PR TITLE
reworked magic strings for InsertText command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The `InsertText` command allows you to insert either static or dynamic text into
 ```kdl
 bind "Cmd T" icon="\u{E10A}" alias="test" description="Insert test text" {
     InsertText {
-        as_is "This is a test"
+        string "This is a test"
     }
 }
 ```
@@ -149,9 +149,7 @@ bind "Cmd T" icon="\u{E10A}" alias="test" description="Insert test text" {
 ```kdl
 bind "Cmd T" {
     InsertText {
-        text {
-            callFunc "myFunction"
-        }
+        callFunc "myFunction"
     }
 }
 ```
@@ -172,6 +170,23 @@ export function getCurrentDayOfWeek() {
 bind "Cmd D" icon="\u{E4E5}" alias="day" description="Insert current day of the week" {
     InsertText {
         callFunc "getCurrentDayOfWeek"
+    }
+}
+```
+
+#### Magic strings
+
+These patterns can be can be used for either `callFunc` or `string`
+- `{{selection}}` -> the currently selected text in a note, can be empty
+- `{||}` -> cursor with no selection
+- `{|}this will be selected{|}` -> cursor with selection, note that both opening and closing markers have to be present
+
+Here is an example of a simple custom command that wraps selection with `[]`, adds `()` and sets the cursor inside
+```kdl
+// (Cmd K): Insert Markdown Link
+bind "Cmd K" icon="\u{E2E2}" alias="link" description="Insert Markdown Link" {
+   InsertText {
+        string "[{{selection}}]({||})"
     }
 }
 ```

--- a/src/command.rs
+++ b/src/command.rs
@@ -107,7 +107,7 @@ impl ScriptCall {
 
 #[derive(Debug, Clone, Hash, knus::Decode, PartialEq, Eq)]
 pub enum TextSource {
-    #[knus(name = "as_is")]
+    #[knus(name = "string")]
     Str(#[knus(argument)] String),
 
     #[knus(name = "callFunc")]

--- a/src/default-notes/default-settings.md
+++ b/src/default-notes/default-settings.md
@@ -21,7 +21,7 @@ Here is an example of a simple custom command that wraps selection with `[]`, ad
 // you can find more icons unicode symbols here: https://phosphoricons.com/ 
 bind "Cmd K" icon="\u{E2E2}" alias="link" description="Insert Markdown Link" {
    InsertText {
-        as_is "[{{selection}}]({||})"
+        string "[{{selection}}]({||})"
     }
 }
 ```

--- a/src/prompts/shelv-system-prompt.md
+++ b/src/prompts/shelv-system-prompt.md
@@ -90,10 +90,10 @@ The `InsertText` command allows you to insert either static or dynamic text into
 
 ```kdl
 bind "Cmd T" icon="\u{E10A}" alias="test" description="Insert test text" {
-				InsertText {
-				        // meaning that this will be directly inserted at the cursor position
-								as_is "This is a test"
-				}
+  InsertText {
+      // meaning that this will be directly inserted at the cursor position
+			string "This is a test"
+	}
 }
 ```
 
@@ -101,12 +101,12 @@ bind "Cmd T" icon="\u{E10A}" alias="test" description="Insert test text" {
 
 ```kdl
 bind "Cmd T" {
-				InsertText {
-								text {
-												// HAS to be an exported js function name
-												callFunc "myFunction"
-  								}
-				}
+  InsertText {
+  	text {
+    	// HAS to be an exported js function name
+			callFunc "myFunction"
+		}
+	}
 }
 ```
 
@@ -158,6 +158,23 @@ export function getCurrentDate() {
 }
 ```
 
+These patterns can be can be used for either `callFunc` or `string`
+- `{{selection}}` -> the currently selected text in a note, can be empty
+- `{||}` -> cursor with no selection
+- `{|}this will be selected{|}` -> cursor with selection, note that both opening and closing markers have to be present
+
+Here is an example of a simple custom command that wraps selection with `[]`, adds `()` and sets the cursor inside
+```kdl
+// (Cmd K): Insert Markdown Link
+bind "Cmd K" icon="\u{E2E2}" alias="link" description="Insert Markdown Link" {
+   InsertText {
+        string "[{{selection}}]({||})"
+    }
+}
+```
+
+---
+
 Key properties for `bind` with `InsertText`:
 
 - `icon`: Phosphor icon unicode (e.g. "\u{E10A}")
@@ -200,7 +217,7 @@ for `bind` keyword
   - Format:
     ```
     InsertText {
-        as_is "Direct text string"
+        string "Direct text string"
         // OR to call a js function
         callFunc "exportedJsFunctionName"
     }


### PR DESCRIPTION
Most importantly I renamed `as_is` which was a silly oversight on my part to`string`, and also added that to both readme and system propmpt