### PR TITLE
Fix link to license on website

### DIFF
--- a/site/src/main.rs
+++ b/site/src/main.rs
@@ -730,7 +730,7 @@ fn faq_items() -> Vec<(&'static str, Element)> {
             div((
                 p((
                     "Shelv is licensed under the ",
-                    link_to("https://github.com/twop/shelv/blob/main/LICENSE", "Komorebi License"),
+                    link_to("https://github.com/twop/shelv/blob/main/LICENSE.md", "Komorebi License"),
                     " 2.0.0. The overall structure is inspired by the ",
                     link_to("https://github.com/LGUG2Z/komorebi", "komorebi project"),
                     "."


### PR DESCRIPTION
I haven't actually run the site to verify the fix (I've done this edit on GitHub, not locally), but I copy-pasted the URL directly from the browser's address bar, so I guess the room for errors is limited. Still, take care.