### PR TITLE
open file button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+Quick reference for AI coding agents working in this repository.
+
+## Build/Test Commands
+- `cargo run` - Run the application
+- `cargo check` - Check code for errors (preferred for development)
+- `cargo test` - Run all tests
+- `cargo test test_name` - Run a single test by name (e.g., `cargo test toggle_heading`)
+- `cargo test --package shelv` - Run tests for main package only
+
+## Code Style
+- **Edition**: Rust 2024 (see rust-toolchain.toml)
+- **Imports**: Group std, external crates, then crate modules; use alphabetical order within groups
+- **Naming**: snake_case for functions/variables, PascalCase for types/enums, SCREAMING_SNAKE for constants
+- **Types**: Prefer explicit types in function signatures; use type inference for locals
+- **Error Handling**: Use `Result` for fallible operations; `.unwrap()` is acceptable for infallible operations or tests
+- **Formatting**: Standard rustfmt conventions
+- **Documentation**: Add doc comments for public APIs; inline comments for complex logic
+
+## Architecture Notes
+- Command-action pattern: user inputs → commands → actions → state mutations
+- Central state in `app_state.rs`, UI rendering in `app_ui.rs`, I/O in `app_io.rs`
+- Text processing uses `text_structure.rs` for markdown-like content parsing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4833,6 +4833,8 @@ dependencies = [
  "linkify",
  "miette 7.5.0",
  "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation 0.2.2",
  "pulldown-cmark",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ egui-phosphor = { version = "0.10.0", features = ["light"] }
 winit = "0.30.12"
 linkify = "0.10.0"
 objc2 = "0.5.1"
+objc2-app-kit = "0.2.2"
+objc2-foundation = "0.2.2"
 boa_engine = "0.20.0"
 boa_parser = "0.20.0"
 boa_runtime = "0.20.0"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ bind "Cmd P" { PinWindow; }
 // (Escape): Hide Window
 bind "Escape" { HideApp; }
 
+// (⌘ O): Open File
+bind "Cmd O" { OpenFileDialog; }
+
+// (⌘ W): Close File
+bind "Cmd W" { CloseCurrentNote; }
+
 // (⌘ 1): Shelf 1
 bind "Cmd 1" { SwitchToNote 0; }
 

--- a/src/actions/external_files.rs
+++ b/src/actions/external_files.rs
@@ -54,7 +54,7 @@ pub fn open_external_file(
                 // Switch to the newly opened file
                 SmallVec::from([AppAction::SwitchToNote {
                     note_file: note_id,
-                    via_shortcut: false,
+                    via_shortcut: true,
                 }])
             }
             Err(err) => {
@@ -86,7 +86,7 @@ pub fn close_external_file(
     if state.selected_note == note_id {
         SmallVec::from([AppAction::SwitchToNote {
             note_file: NoteId::Note(0),
-            via_shortcut: false,
+            via_shortcut: true,
         }])
     } else {
         SmallVec::new()

--- a/src/app_actions.rs
+++ b/src/app_actions.rs
@@ -136,6 +136,7 @@ pub enum AppAction {
     CloseNotification(NotificationId),
     OpenExternalFile(PathBuf),
     CloseExternalFile(ExternalFileId),
+    OpenFileDialog,
 }
 
 impl AppAction {
@@ -232,6 +233,7 @@ pub trait AppIO {
 
     fn watch_external_file(&mut self, external_file: &ExternalFile) -> Result<(), String>;
     fn unwatch_external_file(&mut self, external_file_id: ExternalFileId) -> Result<(), String>;
+    fn open_file_dialog(&self) -> Result<Option<PathBuf>, Box<dyn std::error::Error>>;
 }
 
 pub fn process_app_action(
@@ -1223,6 +1225,22 @@ pub fn process_app_action(
 
         AppAction::CloseExternalFile(file_id) => {
             actions::external_files::close_external_file(file_id, state, app_io)
+        }
+
+        AppAction::OpenFileDialog => {
+            match app_io.open_file_dialog() {
+                Ok(Some(path)) => {
+                    actions::external_files::open_external_file(path, state, app_io)
+                }
+                Ok(None) => {
+                    // User cancelled - no action needed
+                    SmallVec::new()
+                }
+                Err(err) => {
+                    println!("Failed to open file dialog: {}", err);
+                    SmallVec::new()
+                }
+            }
         }
 
         AppAction::WordJump(word_jump_action) => match word_jump_action {

--- a/src/app_io.rs
+++ b/src/app_io.rs
@@ -427,6 +427,10 @@ impl AppIO for RealAppIO {
             .unwatch(watched_file.path)
             .map_err(|err| err.to_string())
     }
+
+    fn open_file_dialog(&self) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+        open_file_dialog_macos()
+    }
 }
 
 fn prepare_shelv_providers(
@@ -626,6 +630,54 @@ fn open_url_with_nsworkspace(url: &str) -> Result<(), Box<dyn std::error::Error>
             Ok(())
         } else {
             Err("NSWorkspace failed to open URL".into())
+        }
+    }
+}
+
+fn open_file_dialog_macos() -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    use objc2::rc::Id;
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send, msg_send_id};
+
+    unsafe {
+        // Create NSOpenPanel instance
+        let panel: Id<AnyObject> = msg_send_id![class!(NSOpenPanel), openPanel];
+
+        // Set panel properties
+        let _: () = msg_send![&panel, setCanChooseFiles: true];
+        let _: () = msg_send![&panel, setCanChooseDirectories: false];
+        let _: () = msg_send![&panel, setAllowsMultipleSelection: false];
+
+        // Run the modal dialog (without file type filtering for now)
+        let response: isize = msg_send![&panel, runModal];
+
+        // NSModalResponseOK = 1
+        if response == 1 {
+            // Get the selected URL
+            let url: *mut AnyObject = msg_send![&panel, URL];
+            if url.is_null() {
+                return Err("Failed to get URL from panel".into());
+            }
+
+            // Get the path from the NSURL
+            let path_nsstring: *mut AnyObject = msg_send![url, path];
+            if path_nsstring.is_null() {
+                return Err("Failed to get path from URL".into());
+            }
+
+            // Convert NSString to UTF8 C string
+            let path_ptr: *const i8 = msg_send![path_nsstring, UTF8String];
+            if path_ptr.is_null() {
+                return Err("Failed to convert path to UTF8".into());
+            }
+
+            let path_cstr = std::ffi::CStr::from_ptr(path_ptr);
+            let path_str = path_cstr.to_str()?.to_string();
+
+            Ok(Some(PathBuf::from(path_str)))
+        } else {
+            // User cancelled
+            Ok(None)
         }
     }
 }

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -518,6 +518,8 @@ impl AppState {
                 CommandInstruction::SwitchToSettings,
                 CommandInstruction::PinWindow,
                 CommandInstruction::HideApp,
+                CommandInstruction::OpenFileDialog,
+                CommandInstruction::CloseCurrentNote,
             ]
             .into_iter()
             .chain(
@@ -750,6 +752,17 @@ fn execute_instruction(
         CI::PinWindow => [AppAction::SetWindowPinned(!ctx.app_state.is_pinned)].into(),
 
         CI::HideApp => [AppAction::HandleMsgToApp(MsgToApp::ToggleVisibility)].into(),
+
+        CI::OpenFileDialog => [AppAction::OpenFileDialog].into(),
+
+        CI::CloseCurrentNote => {
+            match ctx.app_state.selected_note {
+                NoteId::ExternalFileId(file_id) => {
+                    [AppAction::CloseExternalFile(file_id)].into()
+                }
+                _ => SmallVec::new(), // No-op for regular notes
+            }
+        }
 
         // CI::RunLLMBlock => prepare_to_run_llm_block(ctx.app_state, CodeBlockAddress::NoteSelection)
         //     .unwrap_or_default(),

--- a/src/app_ui.rs
+++ b/src/app_ui.rs
@@ -1600,7 +1600,12 @@ fn render_footer_panel(
                     if t.ui_add(
                         IconButton::new(AppIcon::Folder, theme)
                             .size(IconButtonSize::Large)
-                            .tooltip("Open file", None),
+                            .tooltip(
+                            "Open file",
+                            command_list
+                                .find(CommandInstruction::OpenFileDialog)
+                                .and_then(|cmd| cmd.shortcut),
+                        ),
                     )
                     .clicked()
                     {

--- a/src/app_ui.rs
+++ b/src/app_ui.rs
@@ -1,9 +1,9 @@
 use eframe::{
     egui::{
-        self, Button, Context, CursorIcon, FontFamily, FontSelection, Frame, Id, Key,
-        KeyboardShortcut, Label, Layout, Margin, Modal, Modifiers, Painter, Response, RichText,
-        ScrollArea, Sense, Shadow, TextEdit, TextFormat, TextStyle, TextWrapMode, TopBottomPanel,
-        Ui, UiBuilder, UiKind, UiStackInfo, Vec2, WidgetText,
+        self, Context, CursorIcon, FontFamily, FontSelection, Frame, Id, Key, KeyboardShortcut,
+        Label, Layout, Margin, Modal, Modifiers, Painter, Response, RichText, ScrollArea, Sense,
+        Spacing, TextEdit, TextFormat, TextStyle, TextWrapMode, TopBottomPanel, Ui, UiBuilder,
+        UiKind, UiStackInfo, Vec2, WidgetText,
         scroll_area::ScrollBarVisibility,
         text::{CCursor, CCursorRange},
         text_edit::TextEditOutput,
@@ -13,8 +13,8 @@ use eframe::{
     epaint::{Color32, FontId, Rect, Stroke, pos2, vec2},
 };
 use egui_taffy::{
-    Tui, TuiBuilderLogic,
-    taffy::{AlignContent, AlignItems, FlexDirection, JustifyContent},
+    TuiBuilderLogic,
+    taffy::{AlignContent, AlignItems, FlexDirection, FlexboxItemStyle, JustifyContent},
     tui,
 };
 use itertools::Itertools;
@@ -45,7 +45,7 @@ use crate::{
     effects::text_change_effect::TextChange,
     feedback::{Feedback, FeedbackResult},
     persistent_state::{ExternalFile, NoteId},
-    picker::{Picker, PickerItem, PickerItemKind, PickerVisualStyle},
+    picker::{Picker, PickerItem, PickerItemKind, PickerLayoutParams, PickerVisualStyle},
     settings_parsing::format_mac_shortcut_with_symbols,
     taffy_styles::{StyleBuilder, flex_column, flex_row},
     text_structure::{InteractiveTextPart, SpanIndex, TextStructure},
@@ -1438,141 +1438,189 @@ fn render_footer_panel(
 ) -> SmallVec<[AppAction; 1]> {
     let mut actions = SmallVec::new();
     TopBottomPanel::bottom("footer")
-        // .exact_height(32.)
         .show_separator_line(false)
+        .frame(Frame::new().fill(theme.colors.main_bg))
         .show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                let sizes = &theme.sizes;
-                let avail_width = ui.available_width();
-                ui.set_min_size(vec2(avail_width, sizes.header_footer));
+            let sizes = &theme.sizes;
+            ui.set_height(sizes.header_footer_height);
 
-                ui.with_layout(Layout::left_to_right(Align::Center), |ui| {
-                    // Build picker items from opened_files, filtering and organizing by type
-                    let items = opened_files
-                        .iter()
-                        .filter_map(|note_id| match note_id {
-                            NoteId::Note(index) => {
-                                let index = *index;
-                                let cmd = command_list
-                                    .find(CommandInstruction::SwitchToNote(index as u8));
-                                let tooltip = match cmd.and_then(|cmd| cmd.shortcut) {
-                                    Some(shortcut) => {
-                                        format!("Shelf {}", ctx.format_shortcut(&shortcut))
+            let total_available_area = ui.available_rect_before_wrap();
+            let avail_width = ui.available_width();
+            // ui.set_min_size(vec2(avail_width, sizes.header_footer));
+            // ui.painter().debug_rect(
+            //     total_available_area,
+            //     Color32::LIGHT_RED,
+            //     format!("footer={total_available_area:?}"), // sizes.header_footer_height,
+            // );
+
+            let footer_ui_id = ui.id().with("footer");
+
+            tui(ui, footer_ui_id)
+                .style(
+                    flex_row()
+                        .width(avail_width)
+                        .height(sizes.header_footer_height)
+                        .align_items(AlignItems::Center)
+                        .justify_content(JustifyContent::SpaceBetween) // .padding(sizes.xs),
+                        .padding_horizontal(sizes.s),
+                )
+                .show(|t| {
+                    // let ui = t.egui_ui();
+                    // draw_debug_rect(ui);
+                    let footer_available_rect = t.egui_ui().available_rect_before_wrap();
+                    // Left section: Picker with note tabs
+                    t.ui_finite(
+                        |ui| {
+                            // draw_debug_rect(ui);
+                            // Build picker items from opened_files, filtering and organizing by type
+                            let items = opened_files
+                                .iter()
+                                .filter_map(|note_id| match note_id {
+                                    NoteId::Note(index) => {
+                                        let index = *index;
+                                        let cmd = command_list
+                                            .find(CommandInstruction::SwitchToNote(index as u8));
+                                        let tooltip = match cmd.and_then(|cmd| cmd.shortcut) {
+                                            Some(shortcut) => {
+                                                format!("Shelf {}", ctx.format_shortcut(&shortcut))
+                                            }
+                                            None => format!("Shelf {}", index + 1),
+                                        };
+
+                                        Some(PickerItem {
+                                            tooltip,
+                                            kind: PickerItemKind::FontIcon(
+                                                match index {
+                                                    0 => AppIcon::One,
+                                                    1 => AppIcon::Two,
+                                                    2 => AppIcon::Three,
+                                                    3 => AppIcon::Four,
+                                                    _ => AppIcon::More,
+                                                }
+                                                .to_icon_str()
+                                                .to_smolstr(),
+                                                FontId::new(
+                                                    theme.sizes.toolbar_icon,
+                                                    FontFamily::Proportional,
+                                                ),
+                                            ),
+                                            data: *note_id,
+                                        })
                                     }
-                                    None => format!("Shelf {}", index + 1),
-                                };
+                                    NoteId::ExternalFileId(_) => None, // We'll add external files separately
+                                    NoteId::Settings => None, // We'll add settings separately
+                                })
+                                .chain(external_files.iter().map(|ext_file| {
+                                    let file_name = ext_file
+                                        .path
+                                        .file_name()
+                                        .and_then(|n| n.to_str())
+                                        .unwrap_or("external file");
 
-                                Some(PickerItem {
-                                    tooltip,
+                                    PickerItem {
+                                        tooltip: ext_file.path.display().to_string(),
+                                        kind: PickerItemKind::ItemName(
+                                            file_name.to_smolstr(),
+                                            FontId::new(
+                                                theme.fonts.size.normal,
+                                                FontFamily::Proportional,
+                                            ),
+                                        ),
+                                        data: NoteId::ExternalFileId(ext_file.id),
+                                    }
+                                }))
+                                .chain([PickerItem {
+                                    tooltip: {
+                                        let tooltip_text = "Settings";
+                                        command_list
+                                            .find(CommandInstruction::SwitchToSettings)
+                                            .and_then(|cmd| cmd.shortcut)
+                                            .map(|shortcut| {
+                                                format!(
+                                                    "{} {}",
+                                                    tooltip_text,
+                                                    ctx.format_shortcut(&shortcut)
+                                                )
+                                            })
+                                            .unwrap_or_else(|| tooltip_text.to_string())
+                                    },
                                     kind: PickerItemKind::FontIcon(
-                                        match index {
-                                            0 => AppIcon::One,
-                                            1 => AppIcon::Two,
-                                            2 => AppIcon::Three,
-                                            3 => AppIcon::Four,
-                                            _ => AppIcon::More,
-                                        }
-                                        .to_icon_str()
-                                        .to_smolstr(),
+                                        AppIcon::Settings.to_icon_str().to_smolstr(),
                                         FontId::new(
                                             theme.sizes.toolbar_icon,
                                             FontFamily::Proportional,
                                         ),
                                     ),
-                                    data: *note_id,
-                                })
+                                    data: NoteId::Settings,
+                                }])
+                                .collect::<Vec<_>>();
+
+                            let picker = Picker {
+                                current: selected,
+                                items: &items,
+                                layout_params: PickerLayoutParams {
+                                    outline_margin: (sizes.xs / 1.5, sizes.xs / 2.0),
+                                    gap: sizes.xs,
+                                    bottom_rounding: sizes.s,
+                                    top_rounding: sizes.xs,
+                                    entire_available_rect: footer_available_rect
+                                        .shrink2(vec2(theme.sizes.s, 0.0)),
+                                },
+                                style: PickerVisualStyle {
+                                    inactive_color: theme.colors.subtle_text_color,
+                                    hover_color: theme.colors.button_hover_fg,
+                                    pressed_color: theme.colors.button_pressed_fg,
+                                    selected_stroke_color: theme.colors.button_pressed_fg,
+                                    selected_fill_color: theme.colors.button_pressed_fg,
+                                    outline: Stroke::new(1.0, theme.colors.outline_fg),
+                                    tooltip_text_color: theme.colors.subtle_text_color,
+                                },
+                            };
+
+                            let picker_response = picker.show(ui);
+
+                            if let Some(&note_file) = picker_response.inner {
+                                actions.push(AppAction::SwitchToNote {
+                                    note_file,
+                                    via_shortcut: false,
+                                });
                             }
-                            NoteId::ExternalFileId(_) => None, // We'll add external files separately
-                            NoteId::Settings => None,          // We'll add settings separately
-                        })
-                        .chain(external_files.iter().map(|ext_file| {
-                            let file_name = ext_file
-                                .path
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                                .unwrap_or("external file");
 
-                            PickerItem {
-                                tooltip: ext_file.path.display().to_string(),
-                                kind: PickerItemKind::ItemName(
-                                    file_name.to_smolstr(),
-                                    FontId::new(theme.fonts.size.normal, FontFamily::Proportional),
-                                ),
-                                data: NoteId::ExternalFileId(ext_file.id),
-                            }
-                        }))
-                        .chain([PickerItem {
-                            tooltip: {
-                                let tooltip_text = "Settings";
-                                command_list
-                                    .find(CommandInstruction::SwitchToSettings)
-                                    .and_then(|cmd| cmd.shortcut)
-                                    .map(|shortcut| {
-                                        format!(
-                                            "{} {}",
-                                            tooltip_text,
-                                            ctx.format_shortcut(&shortcut)
-                                        )
-                                    })
-                                    .unwrap_or_else(|| tooltip_text.to_string())
-                            },
-                            kind: PickerItemKind::FontIcon(
-                                AppIcon::Settings.to_icon_str().to_smolstr(),
-                                FontId::new(theme.sizes.toolbar_icon, FontFamily::Proportional),
-                            ),
-                            data: NoteId::Settings,
-                        }])
-                        .collect::<Vec<_>>();
-
-                    let picker = Picker {
-                        current: selected,
-                        items: &items,
-                        layout_params: crate::picker::PickerLayoutParams {
-                            outline_margin: (sizes.xs, sizes.xs / 2.0),
-                            gap: sizes.xs,
-                            bottom_rounding: sizes.s,
-                            top_rounding: sizes.s,
+                            picker_response.response
                         },
-                        style: PickerVisualStyle {
-                            inactive_color: theme.colors.subtle_text_color,
-                            hover_color: theme.colors.button_hover_fg,
-                            pressed_color: theme.colors.button_pressed_fg,
-                            selected_stroke_color: theme.colors.button_pressed_fg,
-                            selected_fill_color: theme.colors.button_pressed_fg,
-                            outline: Stroke::new(1.0, theme.colors.outline_fg),
-                            tooltip_text_color: theme.colors.subtle_text_color,
-                        },
-                    };
+                        // |mut val, _ui| {
+                        //     // Return the layout info for taffy
+                        //     val.max_size = val.min_size;
+                        //     val.infinite = egui::Vec2b::FALSE;
+                        //     val
+                        // },
+                    );
 
-                    if let Some(&note_file) = picker.show(ui).inner {
-                        actions.push(AppAction::SwitchToNote {
-                            note_file,
-                            via_shortcut: false,
-                        });
-                    }
-
-                    // Open file dialog button
-                    ui.add_space(sizes.xs);
-                    if ui
-                        .add(
-                            Button::new(
-                                AppIcon::FileOpen.render(
-                                    theme.sizes.toolbar_icon,
-                                    theme.colors.normal_text_color,
-                                ),
-                            )
-                            .frame(false),
-                        )
-                        .on_hover_text("Open File")
-                        .clicked()
+                    // Right section: Open file button
+                    if t.ui_add(
+                        IconButton::new(AppIcon::Folder, theme)
+                            .size(IconButtonSize::Large)
+                            .tooltip("Open file", None),
+                    )
+                    .clicked()
                     {
                         actions.push(AppAction::OpenFileDialog);
                     }
                 });
-            });
         });
 
     actions
+}
+
+fn draw_debug_rect(ui: &Ui) {
+    ui.painter().debug_rect(
+        Rect::from_center_size(
+            ui.available_rect_before_wrap().center(),
+            ui.available_size(),
+        ),
+        Color32::LIGHT_GREEN,
+        format!("available_rect={:?}", ui.available_rect_before_wrap()),
+    );
 }
 
 fn set_menu_bar_style(ui: &mut egui::Ui) {
@@ -1598,19 +1646,21 @@ fn render_header_panel(
 ) -> SmallVec<[AppAction; 1]> {
     TopBottomPanel::top("top_panel")
         .show_separator_line(false)
+        // .exact_height(theme.sizes.header_footer)
+        .frame(Frame::new().fill(theme.colors.main_bg))
         .show(ctx, |ui| {
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
             let mut resulting_actions: SmallVec<[AppAction; 1]> = Default::default();
             let sizes = &theme.sizes;
-
+            ui.set_height(sizes.header_footer_height);
             let avail_width = ui.available_width();
             let avail_rect = ui.available_rect_before_wrap();
             ui.painter().line_segment(
-                [avail_rect.left(), avail_rect.right()]
-                    .map(|x| pos2(x, avail_rect.top() + sizes.header_footer)),
+                [avail_rect.left() + theme.sizes.s, avail_rect.right() - theme.sizes.s]
+                    .map(|x| pos2(x, avail_rect.top() + sizes.header_footer_height)),
                 Stroke::new(1.0, theme.colors.outline_fg),
             );
-            ui.set_min_size(vec2(avail_width, sizes.header_footer));
+            // ui.set_min_size(vec2(avail_width, sizes.header_footer));
 
             let header_ui_id = ui.id().with("header");
 
@@ -1622,10 +1672,10 @@ fn render_header_panel(
                 .style(
                     flex_row()
                         .width(avail_width)
-                        .height(sizes.header_footer)
+                        .height(sizes.header_footer_height)
                         .align_items(AlignItems::Center)
                         .justify_content(JustifyContent::SpaceBetween)
-                        .padding(sizes.xs),
+                        .padding_horizontal(sizes.s),
                 )
                 .show(|t| {
                     // Left section: Close button and title
@@ -1770,7 +1820,7 @@ fn render_header_panel(
                             );
 
                             // Menu button - use ui_add_manual to embed the original menu_button
-                            t.ui_add_manual(
+                            t.ui_finite(
                                 |ui| {
                                     apply_icon_btn_styling(ui.style_mut());
                                     ui.menu_button(
@@ -1846,12 +1896,12 @@ fn render_header_panel(
                                     )
                                     .response
                                 },
-                                |mut val, _ui| {
-                                    // Menu button can grow minimally
-                                    val.max_size = val.min_size;
-                                    val.infinite = egui::Vec2b::FALSE;
-                                    val
-                                },
+                                // |mut val, _ui| {
+                                //     // Menu button can grow minimally
+                                //     val.max_size = val.min_size;
+                                //     val.infinite = egui::Vec2b::FALSE;
+                                //     val
+                                // },
                             );
                         });
                 });

--- a/src/app_ui.rs
+++ b/src/app_ui.rs
@@ -1,9 +1,9 @@
 use eframe::{
     egui::{
-        self, Context, CursorIcon, FontFamily, FontSelection, Frame, Id, Key, KeyboardShortcut,
-        Label, Layout, Margin, Modal, Modifiers, Painter, Response, RichText, ScrollArea, Sense,
-        Shadow, TextEdit, TextFormat, TextStyle, TextWrapMode, TopBottomPanel, Ui, UiBuilder,
-        UiKind, UiStackInfo, Vec2, WidgetText,
+        self, Button, Context, CursorIcon, FontFamily, FontSelection, Frame, Id, Key,
+        KeyboardShortcut, Label, Layout, Margin, Modal, Modifiers, Painter, Response, RichText,
+        ScrollArea, Sense, Shadow, TextEdit, TextFormat, TextStyle, TextWrapMode, TopBottomPanel,
+        Ui, UiBuilder, UiKind, UiStackInfo, Vec2, WidgetText,
         scroll_area::ScrollBarVisibility,
         text::{CCursor, CCursorRange},
         text_edit::TextEditOutput,
@@ -1549,6 +1549,24 @@ fn render_footer_panel(
                             note_file,
                             via_shortcut: false,
                         });
+                    }
+
+                    // Open file dialog button
+                    ui.add_space(sizes.xs);
+                    if ui
+                        .add(
+                            Button::new(
+                                AppIcon::FileOpen.render(
+                                    theme.sizes.toolbar_icon,
+                                    theme.colors.normal_text_color,
+                                ),
+                            )
+                            .frame(false),
+                        )
+                        .on_hover_text("Open File")
+                        .clicked()
+                    {
+                        actions.push(AppAction::OpenFileDialog);
                     }
                 });
             });

--- a/src/command.rs
+++ b/src/command.rs
@@ -343,6 +343,12 @@ pub enum CommandInstruction {
     #[knus(name = "StartWordJump")]
     StartWordJump,
 
+    #[knus(name = "OpenFileDialog")]
+    OpenFileDialog,
+
+    #[knus(name = "CloseCurrentNote")]
+    CloseCurrentNote,
+
     #[knus(name = "ToggleDebugTools")]
     ToggleDebugTools,
 
@@ -352,7 +358,7 @@ pub enum CommandInstruction {
 }
 
 /// Commands that we promote in UI
-pub const PROMOTED_COMMANDS: [CommandInstruction; 10] = const {
+pub const PROMOTED_COMMANDS: [CommandInstruction; 11] = const {
     [
         CommandInstruction::PinWindow,
         CommandInstruction::MarkdownBold,
@@ -365,6 +371,7 @@ pub const PROMOTED_COMMANDS: [CommandInstruction; 10] = const {
         CommandInstruction::MarkdownH3,
         CommandInstruction::ShowPrompt,
         CommandInstruction::StartWordJump,
+        CommandInstruction::OpenFileDialog,
     ]
 };
 
@@ -401,6 +408,8 @@ impl CommandInstruction {
             // Self::RunLLMBlock => "Execute AI Block".into(),
             CommandInstruction::ShowPrompt => "Show AI Prompt".into(),
             CommandInstruction::StartWordJump => "Activate Word Jump".into(),
+            CommandInstruction::OpenFileDialog => "Open File".into(),
+            CommandInstruction::CloseCurrentNote => "Close File".into(),
             CommandInstruction::ToggleDebugTools => "Toggle Debug Tools".into(),
             CommandInstruction::EnterInsideKDL => "Auto indent KDL".into(),
             CommandInstruction::BracketAutoclosingInsideKDL => {
@@ -441,6 +450,8 @@ impl CommandInstruction {
             C::PinWindow => shortcut(Modifiers::COMMAND, Key::P),
             C::ShowPrompt => shortcut(Modifiers::CTRL, Key::Enter),
             C::StartWordJump => shortcut(Modifiers::COMMAND, Key::J),
+            C::OpenFileDialog => shortcut(Modifiers::COMMAND, Key::O),
+            C::CloseCurrentNote => shortcut(Modifiers::COMMAND, Key::W),
             C::ToggleDebugTools => shortcut(Modifiers::ALT.plus(Modifiers::SHIFT).plus(Modifiers::CTRL), Key::D),
             C::EnterInsideKDL => shortcut(Modifiers::NONE, Key::Enter),
             C::BracketAutoclosingInsideKDL => shortcut(Modifiers::SHIFT, Key::OpenBracket),
@@ -481,7 +492,9 @@ impl CommandInstruction {
             // Global commands that work in any context
             C::SwitchToSettings
             | C::PinWindow
-            | C::ToggleDebugTools => (
+            | C::ToggleDebugTools
+            | C::OpenFileDialog
+            | C::CloseCurrentNote => (
                 CommandPhase::InsideRender,
                 CommandCondition::loose_match([UiStateAttribute::Idle])
             ),
@@ -526,6 +539,8 @@ impl CommandInstruction {
             // Self::RunLLMBlock => Some("ExecutePrompt;".into()),
             Self::ShowPrompt => Some("ShowPrompt;".into()),
             Self::StartWordJump => Some("StartWordJump;".into()),
+            Self::OpenFileDialog => Some("OpenFileDialog;".into()),
+            Self::CloseCurrentNote => Some("CloseCurrentNote;".into()),
             Self::ToggleDebugTools => Some("ToggleDebugTools;".into()),
             Self::InsertText(ForwardToChild(source)) => match source {
                 TextSource::Str(text) => {

--- a/src/default-notes/tutorial.md
+++ b/src/default-notes/tutorial.md
@@ -47,6 +47,18 @@ Shelv has a cool word jumping feature that lets you quickly navigate to any word
 *This feature is especially useful for quickly navigating long notes without reaching for your mouse!*
 
 
+## Opening External Files
+You can open files from your computer directly in Shelv to view and edit them alongside your notes.
+
+- [ ] Try it out: Click the folder icon in the bottom-right corner of the footer, or press `⌘ + o` to open a file picker.
+- [ ] Select any text file from your computer to open it in Shelv.
+
+*External files appear as separate tabs and any changes you make are saved automatically.*
+
+*This is perfect for quickly editing config files, viewing logs, or working on any text-based files without leaving Shelv!*
+
+- [ ] Close the opened file by pressing `⌘ + w`
+
 ## Live JS code blocks
 You can do quick math or even write mini programs in shelv directly by making `js` code blocks to come "alive"
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use eframe::{
     egui::{
         self, Align2, FontFamily, FontId, InnerResponse, Response, RichText, Sense, Ui, Vec2,
@@ -25,7 +27,7 @@ struct PickerLayout<'a, Item: PartialEq> {
     items: SmallVec<[PickerItemLayout<'a, Item>; PREALLOCATED_PICKER_ITEMS]>,
     total_width: f32,
     layout_params: PickerLayoutParams,
-    available_rect: Rect,
+    // available_rect: Rect,
 }
 
 #[derive(Debug, Clone)]
@@ -58,6 +60,7 @@ pub struct PickerLayoutParams {
     pub bottom_rounding: f32,
     pub top_rounding: f32,
     pub outline_margin: (f32, f32),
+    pub entire_available_rect: Rect,
 }
 
 pub struct Picker<'a, Item: PartialEq> {
@@ -81,7 +84,7 @@ fn calculate_picker_layout<'a, Item: PartialEq>(
     items: &'a [PickerItem<Item>],
     layout_params: PickerLayoutParams,
     painter: &egui::Painter,
-    available_rect: Rect,
+    // available_rect: Rect,
 ) -> PickerLayout<'a, Item> {
     let mut layout_items = SmallVec::new();
     // just have some safe space
@@ -112,7 +115,7 @@ fn calculate_picker_layout<'a, Item: PartialEq>(
         items: layout_items,
         layout_params,
         total_width,
-        available_rect,
+        // available_rect,
     }
 }
 
@@ -130,9 +133,17 @@ impl<'a, 'b, Item: PartialEq> Widget for PickerResultWrapper<'a, 'b, Item> {
 
         let mut current = original_current;
         let radius = layout_params.bottom_rounding;
-        let available_rect = ui.available_rect_before_wrap();
+        // let available_rect = ui.available_rect_before_wrap();
+        // ui.painter()
+        //     .debug_rect(available_rect, Color32::RED, "picker space");
 
-        let layout = calculate_picker_layout(items, layout_params, &ui.painter(), available_rect);
+        // ui.painter().debug_rect(
+        //     ui.available_rect_before_wrap(),
+        //     Color32::LIGHT_GREEN,
+        //     format!("available_rect={:?}", ui.available_rect_before_wrap()),
+        // );
+
+        let layout = calculate_picker_layout(items, layout_params, &ui.painter());
 
         let desired_size = vec2(layout.total_width, radius * 2.);
         ui.add_space(radius * 2.);
@@ -167,8 +178,8 @@ fn render_picker_items<'items, Item: PartialEq>(
         let item = item_layout.item;
 
         let center = pos2(
-            layout.available_rect.left() + item_layout.offset_x,
-            layout.available_rect.center().y,
+            layout.layout_params.entire_available_rect.left() + item_layout.offset_x,
+            layout.layout_params.entire_available_rect.center().y,
         );
 
         let point_id = picker_id.with(i);
@@ -248,7 +259,7 @@ fn render_picker_items<'items, Item: PartialEq>(
             let animated_height = ctx.animate_value_with_time(
                 picker_id.with("height"),
                 center.y + item_layout.size.y / 2.0
-                    - layout.available_rect.top()
+                    - layout.layout_params.entire_available_rect.top()
                     - selection_y_jump,
                 animation_duration,
             );
@@ -272,7 +283,7 @@ fn render_picker_items<'items, Item: PartialEq>(
                 animation_duration,
             );
 
-            drop_shape.translate([drop_x, layout.available_rect.top()].into());
+            drop_shape.translate([drop_x, layout.layout_params.entire_available_rect.top()].into());
             painter.add(drop_shape);
 
             let (margin_x, _) = layout.layout_params.outline_margin;
@@ -280,24 +291,28 @@ fn render_picker_items<'items, Item: PartialEq>(
             let item_outline_width =
                 animated_item_width + 2. * (margin_x + layout.layout_params.top_rounding);
 
+            // left side of the break line
             painter.line_segment(
                 [
-                    layout.available_rect.left_top(),
+                    layout.layout_params.entire_available_rect.left_top(),
                     pos2(
-                        (drop_x - item_outline_width / 2.0).max(layout.available_rect.left()),
-                        layout.available_rect.top(),
+                        (drop_x - item_outline_width / 2.0)
+                            .max(layout.layout_params.entire_available_rect.left()),
+                        layout.layout_params.entire_available_rect.top(),
                     ),
                 ],
                 Stroke::new(style.outline.width, style.outline.color),
             );
 
+            // right side of the break line
             painter.line_segment(
                 [
                     pos2(
-                        (drop_x + item_outline_width / 2.0).min(layout.available_rect.right()),
-                        layout.available_rect.top(),
+                        (drop_x + item_outline_width / 2.0)
+                            .min(layout.layout_params.entire_available_rect.right()),
+                        layout.layout_params.entire_available_rect.top(),
                     ),
-                    layout.available_rect.right_top(),
+                    layout.layout_params.entire_available_rect.right_top(),
                 ],
                 style.outline.clone(),
             );

--- a/src/prompts/shelv-system-prompt.md
+++ b/src/prompts/shelv-system-prompt.md
@@ -252,6 +252,8 @@ for `bind` keyword
 - `RunLLMBlock`
 - `ShowPrompt`
 - `StartWordJump`
+- `OpenFileDialog`
+- `CloseCurrentNote`
 - `SwitchToNote 1..4`
 - `SwitchToSettings`
 - `InsertText`

--- a/src/taffy_styles.rs
+++ b/src/taffy_styles.rs
@@ -13,6 +13,8 @@ pub trait StyleBuilder {
     fn gap(self, gap: f32) -> Self;
     /// Sets the padding around flex items
     fn padding(self, padding: f32) -> Self;
+    /// Sets the padding around flex items horizontally
+    fn padding_horizontal(self, padding: f32) -> Self;
     /// Sets the width of the flex container
     fn width(self, width: f32) -> Self;
     /// Sets the height of the flex container
@@ -27,6 +29,10 @@ pub trait StyleBuilder {
     fn min_width(self, width: f32) -> Self;
     /// Sets how much the flex item will grow relative to other flex items
     fn grow(self, grow: f32) -> Self;
+    /// The relative rate at which this item shrinks when it is contracting to fit into space
+    ///
+    /// 1.0 is the default value, and this value must be positive.
+    fn shrink(self, shrink: f32) -> Self;
     /// Sets the initial main size of the flex item
     fn basis(self, basis: f32) -> Self;
     /// Sets the direction of the main axis (row or column)
@@ -63,6 +69,13 @@ impl StyleBuilder for Style {
     /// Sets padding around flex items
     fn padding(mut self, padding: f32) -> Self {
         self.padding = length(padding);
+        self
+    }
+
+    /// Sets the padding around flex items horizontally
+    fn padding_horizontal(mut self, padding: f32) -> Self {
+        self.padding.left = length(padding);
+        self.padding.right = length(padding);
         self
     }
 
@@ -105,6 +118,14 @@ impl StyleBuilder for Style {
     /// Sets flex grow factor
     fn grow(mut self, grow: f32) -> Self {
         self.flex_grow = grow;
+        self
+    }
+
+    /// The relative rate at which this item shrinks when it is contracting to fit into space
+    ///
+    /// 1.0 is the default value, and this value must be positive.
+    fn shrink(mut self, shrink: f32) -> Self {
+        self.flex_shrink = shrink;
         self
     }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -40,6 +40,7 @@ pub enum AppIcon {
     Copy,
     Download,
     Bug,
+    FileOpen,
 }
 
 impl AppIcon {
@@ -178,6 +179,7 @@ impl AppIcon {
             AppIcon::Copy => P::COPY_SIMPLE,
             AppIcon::Download => P::DOWNLOAD_SIMPLE,
             AppIcon::Bug => P::BUG,
+            AppIcon::FileOpen => P::FOLDER_OPEN,
         }
     }
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeMap;
 
 use eframe::{
     egui::{
-        self, FontDefinitions, RichText, TextStyle, ThemePreference, Vec2, Visuals, WidgetText,
+        self, FontDefinitions, Margin, RichText, TextStyle, ThemePreference, Vec2, Visuals,
+        WidgetText,
         style::{NumericColorSpace, Selection, TextCursorStyle, WidgetVisuals, Widgets},
         vec2,
     },
@@ -197,7 +198,7 @@ pub struct Sizes {
     pub menu_height: f32,
 
     // semantic
-    pub header_footer: f32,
+    pub header_footer_height: f32,
     pub toolbar_icon: f32,
 }
 
@@ -267,7 +268,7 @@ impl Sizes {
             xl,
             menu_width,
             menu_height,
-            header_footer: xl + xs,
+            header_footer_height: xl + xs, // 28.0
             toolbar_icon: l + xs / 2.,
         }
     }
@@ -476,7 +477,8 @@ pub fn configure_styles(ctx: &egui::Context, theme: &AppTheme) {
 
     style.text_styles = text_styles(&theme.fonts);
     style.visuals = visuals(&theme.colors);
-    style.spacing.item_spacing = Vec2::splat(theme.sizes.s);
+    style.spacing.item_spacing = Vec2::splat(0.);
+    style.spacing.window_margin = Margin::same(0);
     // style.spacing.button_padding = Vec2::splat(theme.sizes.s);
     style.interaction.tooltip_delay = 0.05;
     ctx.set_style(style);


### PR DESCRIPTION
closes #203 

Opening and closing external files in Shelv, wihtout pretty visuals (for now):

- macOS native file picker integration using Objective-C APIs
- New command instructions for opening and closing files (OpenFileDialog, CloseCurrentNote)
- UI updates to the footer panel with a new "Open File" button
- New keyboard shortcuts (Cmd+O to open files, Cmd+W to close files)
- Refactored footer UI to use egui_taffy, though it is a gigantic pain. I need to rething/rework it.